### PR TITLE
chore(setup): Remove py26 support, adjust status to '3 - Alpha'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache:
 language: python
 matrix:
   include:
-  - python: '2.6'
-    env: TOXENV=py26
   - python: '2.7'
     env: TOXENV=py27
   - python: '3.4'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description='Falcon middleware for sanity-checking that HTTPS was used for the request.',
     long_description=io.open('README.rst', 'r', encoding='utf-8').read(),
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Natural Language :: English',
         'Intended Audience :: Developers',
@@ -28,7 +28,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
@@ -39,7 +38,7 @@ setup(
     url='https://github.com/falconry/falcon-require-https',
     license='Apache 2.0',
     packages=find_packages(exclude=['tests']),
-    install_requires=[],
+    install_requires=['falcon'],
     setup_requires=['pytest-runner'],
     tests_require=['falcon', 'pytest'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py26,
-          py27,
+envlist = py27,
           py34,
           py35,
           pep8,


### PR DESCRIPTION
This patch does the following:

* Removes py26 support. It still works with 2.6 but we don't want
  the burden of officially supporting this deprecated version of
  Python.
* Adjusts the status classifier to '3 - Alpha' since this
  middleware is brand new.
* Adds falcon to install_requires, since the middleware does
  reference the falcon module.